### PR TITLE
Add persistent Zuntopia credit button

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -23,11 +23,13 @@
   .actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
   pre{white-space:pre-wrap;background:#0f1116;border:1px solid #2a2f39;border-radius:12px;padding:20px;max-height:52vh;overflow:auto;line-height:1.7}
   .sep{height:18px}
+  #credit-container{margin-top:24px;text-align:center}
+  #credit-container .btn{width:auto}
 </style>
 <script>
 /* GLOBAL FUNCTIONS — no arrow funcs, simple handlers, plus onload init */
 function $(id){ return document.getElementById(id); }
-function init(){ var s=$('status'); if(s){ s.textContent='Ready ✅ (JS loaded)'; } }
+function init(){ var s=$('status'); if(s){ s.textContent='Ready ✅ (JS loaded)'; } ensureCredit(); }
 function setStatus(msg){ $('status').textContent = msg; }
 function pad2(n){ n=parseInt(n,10)||0; return n<10? '0'+n : ''+n; }
 function stripTime(d){ return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
@@ -121,6 +123,16 @@ function downloadTxt(){
   var blob=new Blob([$(`output`).value],{type:'text/plain'}); var a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='sabbath-school_'+lang+'_'+nameQ+'_week-'+w+'_'+version+'.txt'; a.click(); setTimeout(function(){ URL.revokeObjectURL(a.href); }, 2000);
 }
 function testJS(){ setStatus('✅ JavaScript is running. Try Auto: This Week.'); }
+function ensureCredit(){
+  if(!document.getElementById('zuntopia-credit')){
+    var div=document.createElement('div');
+    div.id='credit-container';
+    div.innerHTML='<button id="zuntopia-credit" class="btn secondary" onclick="window.open(\'https://zuntopia.com\', \'_blank\')">Created by zuntopia.com</button>';
+    var wrap=document.querySelector('.wrap');
+    if(wrap){ wrap.appendChild(div); }
+  }
+}
+new MutationObserver(ensureCredit).observe(document.body,{childList:true,subtree:true});
 </script>
 </head>
 <body onload="init()">

--- a/app/src/main/java/com/zuntopia/sabbath_school_weekly/MainActivity.kt
+++ b/app/src/main/java/com/zuntopia/sabbath_school_weekly/MainActivity.kt
@@ -1,18 +1,33 @@
 package com.zuntopia.sabbath_school_weekly
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            WebContent()
+            Box(modifier = Modifier) {
+                WebContent()
+                CreditButton(modifier = Modifier.align(Alignment.BottomEnd))
+            }
         }
     }
 }
@@ -26,4 +41,19 @@ fun WebContent() {
             loadUrl("file:///android_asset/index.html")
         }
     })
+}
+
+@Composable
+fun CreditButton(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    Button(
+        onClick = {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://zuntopia.com"))
+            context.startActivity(intent)
+        },
+        modifier = modifier.padding(8.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Text("Created by zuntopia.com")
+    }
 }


### PR DESCRIPTION
## Summary
- Overlay a "Created by zuntopia.com" button that opens zuntopia.com
- Inject a credit button into the embedded web content with a MutationObserver to restore it if removed

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e275daf08329908c309d1f4dc621