### PR TITLE
Require retaining Zuntopia link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ You are free to:
 - Adapt — remix, transform, and build upon the material
 
 Under the following terms:
-- Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+- Attribution — You must give appropriate credit, include a visible link to https://zuntopia.com, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. The link to https://zuntopia.com must remain intact and may not be removed.
 - NonCommercial — You may not use the material for commercial purposes.
 - ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
 - No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.


### PR DESCRIPTION
## Summary
- require attribution include a visible link to zuntopia.com

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e55657e88329969469072703a786